### PR TITLE
added active class style for mx-navigationtree menu items (Fixes #1)

### DIFF
--- a/styles/lib/components/_navigation.scss
+++ b/styles/lib/components/_navigation.scss
@@ -135,7 +135,7 @@
 			}
 
 			a:hover,
-			a:focus {
+			a:focus{
 				background-color: $color-nav-bg-hover;
 				color: $color-nav-text-active;
 				text-decoration: none;
@@ -145,6 +145,11 @@
 					border-bottom-color: $color-nav-text-active;
 				}
 			}
+            
+            a.active{
+				color: $color-nav-text-active;
+				text-decoration: none;
+            }
 		}
 	}
 

--- a/styles/lib/lib.css
+++ b/styles/lib/lib.css
@@ -443,6 +443,7 @@ textarea.form-control, textarea.readonly-input { height: auto; }
 .mx-navigationtree .navbar-inner ul li a .caret { border-top-color: #bbc0cf; border-bottom-color: #bbc0cf; }
 .mx-navigationtree .navbar-inner ul li a img { margin-right: 4px; width: 20px; height: auto; }
 .mx-navigationtree .navbar-inner ul li a:hover, .mx-navigationtree .navbar-inner ul li a:focus { background-color: #43485d; color: white; text-decoration: none; }
+.mx-navigationtree .navbar-inner ul li a.active { color: white; text-decoration: none; }
 .mx-navigationtree .navbar-inner ul li a:hover .caret, .mx-navigationtree .navbar-inner ul li a:focus .caret { border-top-color: white; border-bottom-color: white; }
 .mx-navigationtree li.mx-navigationtree-has-items > ul { margin: 0; padding-left: 0; background-color: #313645; }
 .mx-navigationtree li.mx-navigationtree-has-items > ul li { margin: 0; padding: 0; }


### PR DESCRIPTION
Hi

fixes #1

"When navigating using the side-menu there is no styling for the active menu item.
If the menu item has the focus then there is styling but when you click into the center layout-container it goes back to looking like a normal menu item."

I've just added the active class styling into the _navigation.scss and lib.css.

Let me know if I've missed anything.

Thanks
Trevor
